### PR TITLE
Update for PHP 8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,5 +176,5 @@ workflows:
       - matrix-conditions:
           matrix:
             parameters:
-              version: ["7.4", "8.0", "8.1"]
+              version: ["7.4", "8.0", "8.1", "8.2"]
               install-flags: ["", "--prefer-lowest"]

--- a/rector.php
+++ b/rector.php
@@ -7,8 +7,14 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\LevelSetList;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
+use Rector\PHPUnit\Rector\MethodCall\GetMockBuilderGetMockToCreateMockRector;
+use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
   $rectorConfig->paths([
@@ -16,7 +22,34 @@ return static function (RectorConfig $rectorConfig): void {
     __DIR__ . '/tests',
   ]);
 
-  $rectorConfig->sets([
-    LevelSetList::UP_TO_PHP_74,
+  $rectorConfig->rules([
+    CompleteDynamicPropertiesRector::class,
   ]);
+
+  $rectorConfig->sets([
+    // Please no dead code or unneeded variables.
+    SetList::DEAD_CODE,
+    // Try to figure out type hints.
+    SetList::TYPE_DECLARATION,
+    // Interestingly, LevelSetList::UP_TO_PHP_82 does not preserve PHP 7.4,
+    // so we have to specify all the PHP versions leading up to it if we
+    // want to keep 7.4 idioms.
+    SetList::PHP_74,
+    SetList::PHP_80,
+    SetList::PHP_81,
+    SetList::PHP_82,
+  ]);
+
+  $rectorConfig->skip([
+    // Keep getMockBuilder() for now.
+    GetMockBuilderGetMockToCreateMockRector::class,
+    // Don't throw errors on JSON parse problems. Yet.
+    // @todo Throw errors and deal with them appropriately.
+    JsonThrowOnErrorRector::class,
+    // We like our tags.
+    RemoveUselessParamTagRector::class,
+    RemoveUselessVarTagRector::class,
+    RemoveUselessReturnTagRector::class,
+  ]);
+
 };

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -12,6 +12,16 @@ namespace PDLT;
 class Converter implements ConverterInterface {
 
   /**
+   * @var \PDLT\ParserInterface
+   */
+  public $parser;
+
+  /**
+   * @var \PDLT\CompilerInterface
+   */
+  public $compiler;
+
+  /**
    * Build date format converter using the given parser and compiler.
    */
   public function __construct(ParserInterface $parser, CompilerInterface $compiler) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -11,6 +11,11 @@ namespace PDLT;
 class Parser implements ParserInterface {
 
   /**
+   * @var \PDLT\GrammarInterface
+   */
+  public $grammar;
+
+  /**
    * Creates a date format parser.
    *
    * @param \PDLT\GrammarInterface $grammar

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -2,9 +2,9 @@
 
 namespace PDLT\Tests;
 
-use PDLT\Compiler;
-use PDLT\CompilationMapInterface;
 use PDLT\CompilationMap\MySQL;
+use PDLT\CompilationMapInterface;
+use PDLT\Compiler;
 use PDLT\DirectiveToken;
 use PDLT\TokenInterface;
 use PDLT\UnsupportedTokenException;
@@ -18,7 +18,7 @@ class CompilerTest extends TestCase {
   /**
    * @covers ::compileToken
    */
-  public function testCompileTokenException() {
+  public function testCompileTokenException(): void {
     $this->expectException(UnsupportedTokenException::class);
     $this->expectExceptionMessage('Unable to compile unsupported token type');
 
@@ -32,7 +32,7 @@ class CompilerTest extends TestCase {
   /**
    * @covers ::compileDirective
    */
-  public function testCompileDirectiveException() {
+  public function testCompileDirectiveException(): void {
     $this->expectException(UnsupportedTokenException::class);
     $this->expectExceptionMessage('Unable to compile unsupported directive "this-directive-should-not-exist"; not found in compilation map "PDLT\CompilationMap\MySQL".');
 

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -2,12 +2,11 @@
 
 namespace PDLT\Tests;
 
-use PDLT\Converter;
-use PDLT\Parser;
-use PDLT\Compiler;
-use PDLT\Grammar\Strptime;
 use PDLT\CompilationMap\MySQL;
-
+use PDLT\Compiler;
+use PDLT\Converter;
+use PDLT\Grammar\Strptime;
+use PDLT\Parser;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ConverterTest extends TestCase {
 
-  public function provideFormats() {
+  public function provideFormats(): array {
     return [
       'from-readme' => ['%c/%e/%y', '%-m/%-d/%y'],
       ['%a', '%a'],
@@ -50,7 +49,7 @@ class ConverterTest extends TestCase {
   /**
    * @dataProvider provideFormats
    */
-  public function testStrptimeToMySqlConverter($expected, $input_format) {
+  public function testStrptimeToMySqlConverter(string $expected, string $input_format): void {
     $converter = new Converter(
       new Parser(new Strptime()),
       new Compiler(new MySQL())

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -16,7 +16,7 @@ class ParserTest extends TestCase {
    * @covers ::lex
    * @see https://www.php.net/manual/en/function.strftime.php
    */
-  public function testLexException() {
+  public function testLexException(): void {
     $this->expectException(UnknownTokenException::class);
     $this->expectExceptionMessage('Invalid format provided; token "%i" not found in grammar "PDLT\Grammar\Strptime".');
 


### PR DESCRIPTION
Ensure pdlt works with PHP 8.2, taking the opportunity to use Rector to do some code quality work.